### PR TITLE
Add current bait and rod item relations

### DIFF
--- a/migrations/versions/4fc4d647ffad_add_current_item_relations.py
+++ b/migrations/versions/4fc4d647ffad_add_current_item_relations.py
@@ -1,6 +1,6 @@
 """Add player's current bait and rod item relations
 
-Revision ID: 854f163d2740
+Revision ID: 4fc4d647ffad
 Revises: 65e668ad3010
 Create Date: 2025-06-04 00:00:00.000000
 """
@@ -9,7 +9,7 @@ from alembic import op
 import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
-revision = '854f163d2740'
+revision = '4fc4d647ffad'
 down_revision = '65e668ad3010'
 branch_labels = None
 depends_on = None

--- a/migrations/versions/854f163d2740_player_current_item_relations.py
+++ b/migrations/versions/854f163d2740_player_current_item_relations.py
@@ -1,0 +1,31 @@
+"""Add player's current bait and rod item relations
+
+Revision ID: 854f163d2740
+Revises: 65e668ad3010
+Create Date: 2025-06-04 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '854f163d2740'
+down_revision = '65e668ad3010'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('player', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('current_bait_item_id', sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column('current_rod_item_id', sa.Integer(), nullable=True))
+        batch_op.create_foreign_key('fk_player_current_bait_item', 'item', ['current_bait_item_id'], ['id'])
+        batch_op.create_foreign_key('fk_player_current_rod_item', 'item', ['current_rod_item_id'], ['id'])
+
+
+def downgrade():
+    with op.batch_alter_table('player', schema=None) as batch_op:
+        batch_op.drop_constraint('fk_player_current_bait_item', type_='foreignkey')
+        batch_op.drop_constraint('fk_player_current_rod_item', type_='foreignkey')
+        batch_op.drop_column('current_bait_item_id')
+        batch_op.drop_column('current_rod_item_id')

--- a/models/item/item.py
+++ b/models/item/item.py
@@ -23,7 +23,11 @@ class Item(BaseEntity):
 
     # Player relationship (One-to-Many)
     player_id = db.Column(db.Integer, db.ForeignKey('player.id'))
-    player = db.relationship('Player', back_populates='items')
+    player = db.relationship(
+        'Player',
+        back_populates='items',
+        foreign_keys=[player_id]
+    )
 
     # Reverse relationships for a player's currently selected items
     current_bait_for_player = db.relationship(

--- a/models/item/item.py
+++ b/models/item/item.py
@@ -25,6 +25,20 @@ class Item(BaseEntity):
     player_id = db.Column(db.Integer, db.ForeignKey('player.id'))
     player = db.relationship('Player', back_populates='items')
 
+    # Reverse relationships for a player's currently selected items
+    current_bait_for_player = db.relationship(
+        'Player',
+        back_populates='current_bait_item',
+        foreign_keys='Player.current_bait_item_id',
+        uselist=False
+    )
+    current_rod_for_player = db.relationship(
+        'Player',
+        back_populates='current_rod_item',
+        foreign_keys='Player.current_rod_item_id',
+        uselist=False
+    )
+
     # Trade relationships (One-to-Many for given and taken)
     trade_given_id = db.Column(db.Integer, db.ForeignKey('trade.id'))
     trade_given = db.relationship('Trade', back_populates='items_given', foreign_keys=[trade_given_id])

--- a/models/player/player.py
+++ b/models/player/player.py
@@ -37,9 +37,32 @@ class Player(Account):
 
     outfit_id = db.Column(db.Integer, db.ForeignKey('outfit.id'), unique=True)
     outfit = db.relationship('Outfit', back_populates='player', uselist=False)
-    
+
     # Reverse relationship for Item_Player
     items = db.relationship('Item', back_populates='player', foreign_keys='Item.player_id', lazy='dynamic')
+
+    # Currently selected bait and rod items
+    current_bait_item_id = db.Column(
+        db.Integer,
+        db.ForeignKey('item.id', use_alter=True, name='fk_player_current_bait_item')
+    )
+    current_bait_item = db.relationship(
+        'Item',
+        foreign_keys=[current_bait_item_id],
+        back_populates='current_bait_for_player',
+        uselist=False
+    )
+
+    current_rod_item_id = db.Column(
+        db.Integer,
+        db.ForeignKey('item.id', use_alter=True, name='fk_player_current_rod_item')
+    )
+    current_rod_item = db.relationship(
+        'Item',
+        foreign_keys=[current_rod_item_id],
+        back_populates='current_rod_for_player',
+        uselist=False
+    )
 
     # One-to-one relationships (reverse side)
     settings = db.relationship("PlayerSettings", back_populates="player", uselist=False)

--- a/seed.py
+++ b/seed.py
@@ -63,12 +63,17 @@ def seed_db():
         MoneyTree(player=player, level=1).create()
         FishingLine(player=player, level=1, color='red').create()
 
-        Item(amount=5, item_type=InventoryType.Bait, bait=bait, player=player).create()
-        Item(amount=1, item_type=InventoryType.Rod, rod=rod, player=player).create()
+        bait_item = Item(amount=5, item_type=InventoryType.Bait, bait=bait, player=player).create()
+        rod_item = Item(amount=1, item_type=InventoryType.Rod, rod=rod, player=player).create()
         Item(amount=1, item_type=InventoryType.Look, look=look, player=player).create()
         Item(amount=2, item_type=InventoryType.Fruit, fruit=fruit, player=player).create()
         Item(amount=1, item_type=InventoryType.Decoration, decoration=decoration, player=player).create()
         ShopItem(amount=1, item_type=InventoryType.Bait, bait=bait).create()
+
+        # Set player's currently selected bait and rod
+        player.current_bait_item = bait_item
+        player.current_rod_item = rod_item
+        player.commit()
 
         Payment(created_date=datetime.utcnow(), owner='owner').create()
 


### PR DESCRIPTION
## Summary
- link `Player` to selected `Item` for current bait and rod
- expose relationships in `Item` back to the owning `Player`
- include Alembic migration for new columns